### PR TITLE
Fixed bug with stage browser showing blank when fully completed

### DIFF
--- a/src/popups/StagesPopup/index.cpp
+++ b/src/popups/StagesPopup/index.cpp
@@ -118,7 +118,14 @@ void StagesPopup::drawCurrentStage()
   Padding padding{55.f, 10.f, 10.f, 10.f}; // top, bottom, left, right
 
   auto profile = GlobalStore::get()->getProfileByLevel(m_levelId);
-  Stage *currentStage = profile ? getFirstUncheckedStage(*profile) : nullptr;
+  Stage* currentStage = nullptr;
+
+  if (profile && !profile->data.stages.empty()) {
+    currentStage = getFirstUncheckedStage(*profile);
+    if (!currentStage) {
+      currentStage = &profile->data.stages.back();
+    }
+  }
 
   const auto contentSize = CCSize(
       m_size.width - padding.left - padding.right,
@@ -248,8 +255,25 @@ void StagesPopup::drawCurrentStageTitle(std::vector<Stage> &stages, Padding padd
 
   std::string stat = "";
 
-  float totalAttempts = metaInfo.currStageAttempts;
-  float totalTimePlayed = metaInfo.currStagePlaytime;
+  float totalAttempts = 0;
+  float totalTimePlayed = 0;
+
+  Stage* currentStage = metaInfo.currentStage;
+  if (!currentStage && !stages.empty()) {
+    currentStage = &stages.back();
+  }
+
+  if (currentStage)
+  {
+    for (const auto& range : currentStage->ranges)
+    {
+      if (range.consider)
+      {
+        totalAttempts += range.attempts;
+        totalTimePlayed += range.timePlayed;
+      }
+    }
+  }
 
   stat += fmt::format("{} <small>Attempts</small> ", totalAttempts);
   stat += formatTimePlayed(totalTimePlayed);

--- a/src/popups/StagesPopup/ui/StageList/StageListLayer.cpp
+++ b/src/popups/StagesPopup/ui/StageList/StageListLayer.cpp
@@ -46,9 +46,6 @@ bool StageListLayer::init(
     m_stages = &m_profile->data.stages;
     m_currentIndex = m_stage->stage - 1;
     m_uncheckedStage = getFirstUncheckedStage(*m_profile);
-
-    if (!m_uncheckedStage)
-      return true;
   }
 
   if (!m_stages || m_stages->size() <= 0)
@@ -138,12 +135,13 @@ bool StageListLayer::init(
 
 void StageListLayer::reload()
 {
-  if (!m_stage || !m_uncheckedStage)
+  if (!m_stage) {
     return;
+  }
 
   drawArrows();
 
-  bool isDisabled = m_stage->stage > m_uncheckedStage->stage;
+  bool isDisabled = m_uncheckedStage && m_stage->stage > m_uncheckedStage->stage;
   m_scroll->m_contentLayer->removeAllChildrenWithCleanup(true);
   m_lockSpr->setVisible(isDisabled);
 
@@ -153,6 +151,7 @@ void StageListLayer::reload()
   const float cellWidth = (totalWidth - gap) / 2.f;
 
   std::vector<Range *> visibleRanges;
+  
   for (auto &r : m_stage->ranges)
     if (r.consider)
     {
@@ -229,8 +228,8 @@ void StageListLayer::setRunsVisabilityForCompleted(bool visible)
 void StageListLayer::drawArrows()
 {
   const auto stagesMetaInfo = getMetaInfoFromStages(*m_stages);
-
-  if (!m_stages || stagesMetaInfo.consideredStages->empty() || stagesMetaInfo.consideredStages->size() < 2 || !stagesMetaInfo.currentStage)
+  
+  if (!m_stages || !m_stage || stagesMetaInfo.consideredStages->empty() || stagesMetaInfo.consideredStages->size() < 2)
     return;
 
   if (m_buttonMenuLeft)


### PR DESCRIPTION
## Summary
Fixes Stage Browser behaviour for fully completed profiles.
After making the stage browser not display as completely blank for completed profiles, encountered a couple of other issues
- Attempts / Time Played were both 0 until going back and forth between stages
- Would open on Stage 1 rather than the final Stage for fully completed profiles
- Arrows would not draw for fully completed profiles

## Changes
- Fall back to the last stage rather than first stage when there is no unchecked stage
- Prevent StageListLayer from returning when `m_uncheckedStage` is null (invalid logic check)
- Made reload logic valid for fully completed profiles
- Allow stage arrows to render without requiring `metaInfo.currentStage`
- Fixed initial header stats so Attempts / Time Played are correct on first open

## Bug
Previously, fully completed profiles would open as completely blank
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/6cbda4f6-b9ac-4b3a-a32c-ce1d9ee7b3d4" />


## Result
Completed profiles now open correctly on the final stage with proper stats and working stage navigation.
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/019a1b38-d45f-4031-9f5b-1facc3b14a8b" />
Also tested creating a new profile with no start pos to ensure nothing is broken/crashing, and it creates as follows which seems to be intended behaviour:
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/4698e270-41b0-4d1e-a54d-e4ed45868990" />
